### PR TITLE
Generalize hasher that can be used for hash functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(map_first_last)]
 #![feature(trivial_bounds)]
 
 #[global_allocator]

--- a/src/merk/chunks.rs
+++ b/src/merk/chunks.rs
@@ -96,7 +96,7 @@ impl<'a> ChunkProducer<'a> {
             return Ok(self.trunk.encode()?);
         }
 
-        assert!(!(self.index >= self.len()), "Called next_chunk after end");
+        assert!(self.index < self.len(), "Called next_chunk after end");
 
         let end_key = self.chunk_boundaries.get(self.index - 1);
         let end_key_slice = end_key.as_ref().map(|k| k.as_slice());
@@ -207,7 +207,7 @@ mod tests {
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let path = format!("chunks_from_reopen_{}.db", time);
+        let path = format!("chunks_from_reopen_{time}.db");
 
         let original_chunks = {
             let mut merk = Merk::open(&path).unwrap();

--- a/src/proofs/chunk.rs
+++ b/src/proofs/chunk.rs
@@ -303,7 +303,7 @@ mod tests {
         assert!(!has_more);
 
         println!("{:?}", &proof);
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
 
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
@@ -318,7 +318,7 @@ mod tests {
 
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(has_more);
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
 
         let counts = count_node_types(trunk);
         // are these formulas correct for all values of `MIN_TRUNK_HEIGHT`? 🤔
@@ -339,7 +339,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 1);
@@ -358,7 +358,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
@@ -377,7 +377,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
@@ -398,7 +398,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 3);
@@ -419,7 +419,7 @@ mod tests {
         let mut iter = merk.db.raw_iterator();
         iter.seek_to_first();
         let chunk = get_next_chunk(&mut iter, None).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(ops, merk.root_hash()).unwrap();
         let counts = count_node_types(chunk);
         assert_eq!(counts.kv, 31);
@@ -432,7 +432,7 @@ mod tests {
 
         // left leaf
         let chunk = get_next_chunk(&mut iter, Some(root_key.as_slice())).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(
             ops,
             [
@@ -448,7 +448,7 @@ mod tests {
 
         // right leaf
         let chunk = get_next_chunk(&mut iter, None).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(
             ops,
             [

--- a/src/proofs/query/mod.rs
+++ b/src/proofs/query/mod.rs
@@ -274,7 +274,7 @@ where
         };
         let mut left_ops = self.execute_child_query(true, left_items)?;
         let mut right_ops = self.execute_child_query(false, right_items)?;
-        if let Ok(_) = search {
+        if search.is_ok() {
             left_ops.push_back(Op::Push(self.to_kv_node()));
         }
         left_ops.append(&mut right_ops);

--- a/src/test_utils/crash_merk.rs
+++ b/src/test_utils/crash_merk.rs
@@ -74,7 +74,7 @@ mod tests {
     fn crash() {
         let path = std::thread::current().name().unwrap().to_owned();
 
-        let mut merk = CrashMerk::open(&path).expect("failed to open merk");
+        let mut merk = CrashMerk::open(path).expect("failed to open merk");
         merk.apply(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[])
             .expect("apply failed");
         unsafe {

--- a/src/test_utils/temp_merk.rs
+++ b/src/test_utils/temp_merk.rs
@@ -24,7 +24,7 @@ impl TempMerk {
             .unwrap()
             .as_nanos();
         let mut path = temp_dir();
-        path.push(format!("merk-temp–{}", time));
+        path.push(format!("merk-temp–{time}"));
         TempMerk::open(path)
     }
 }

--- a/src/tree/encoding.rs
+++ b/src/tree/encoding.rs
@@ -173,8 +173,8 @@ mod tests {
         }) = tree.link(true)
         {
             assert_eq!(*key, [2]);
-            assert_eq!(*child_heights, (123 as u8, 124 as u8));
-            assert_eq!(*hash, [66 as u8; 32]);
+            assert_eq!(*child_heights, (123_u8, 124_u8));
+            assert_eq!(*hash, [66_u8; 32]);
         } else {
             panic!("Expected Link::Reference");
         }

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -17,18 +17,17 @@ pub type Hash = [u8; HASH_LENGTH];
 ///
 /// **NOTE:** This will panic if the key is longer than 255 bytes, or the value
 /// is longer than 65,535 bytes.
-pub fn kv_hash(key: &[u8], value: &[u8]) -> Hash {
+pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Hash {
     // TODO: result instead of panic
-    // TODO: make generic to allow other hashers
-    let mut hasher = Hasher::new();
-    hasher.update(&[0]);
+    let mut hasher = D::new();
+    hasher.update([0]);
 
     let key_length = u32::try_from(key.len()).expect("key must be less than 2^32 bytes");
-    hasher.update(&key_length.to_le_bytes());
+    hasher.update(key_length.to_le_bytes());
     hasher.update(key);
 
     let val_length = u32::try_from(value.len()).expect("value must be less than 2^32 bytes");
-    hasher.update(&val_length.to_le_bytes());
+    hasher.update(val_length.to_le_bytes());
     hasher.update(value);
 
     let res = hasher.finalize();
@@ -39,10 +38,9 @@ pub fn kv_hash(key: &[u8], value: &[u8]) -> Hash {
 
 /// Hashes a node based on the hash of its key/value pair, the hash of its left
 /// child (if any), and the hash of its right child (if any).
-pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
-    // TODO: make generic to allow other hashers
-    let mut hasher = Hasher::new();
-    hasher.update(&[1]);
+pub fn node_hash<D: Digest>(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
+    let mut hasher = D::new();
+    hasher.update([1]);
     hasher.update(kv);
     hasher.update(left);
     hasher.update(right);

--- a/src/tree/kv.rs
+++ b/src/tree/kv.rs
@@ -1,4 +1,4 @@
-use super::hash::{kv_hash, Hash, HASH_LENGTH, NULL_HASH};
+use super::hash::{kv_hash, Hash, Hasher, HASH_LENGTH, NULL_HASH};
 use ed::{Decode, Encode, Result};
 use std::io::{Read, Write};
 
@@ -19,7 +19,7 @@ impl KV {
     #[inline]
     pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
         // TODO: length checks?
-        let hash = kv_hash(key.as_slice(), value.as_slice());
+        let hash = kv_hash::<Hasher>(key.as_slice(), value.as_slice());
         KV { key, value, hash }
     }
 
@@ -36,7 +36,7 @@ impl KV {
     pub fn with_value(mut self, value: Vec<u8>) -> Self {
         // TODO: length check?
         self.value = value;
-        self.hash = kv_hash(self.key(), self.value());
+        self.hash = kv_hash::<Hasher>(self.key(), self.value());
         self
     }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -16,7 +16,7 @@ use ed::{Decode, Encode};
 
 use super::error::Result;
 pub use commit::{Commit, NoopCommit};
-pub use hash::{kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH};
+pub use hash::{kv_hash, node_hash, Hash, Hasher, HASH_LENGTH, NULL_HASH};
 use kv::KV;
 pub use link::Link;
 pub use ops::{Batch, BatchEntry, Op, PanicSource};
@@ -155,7 +155,7 @@ impl Tree {
     /// Computes and returns the hash of the root node.
     #[inline]
     pub fn hash(&self) -> Hash {
-        node_hash(
+        node_hash::<Hasher>(
             self.inner.kv.hash(),
             self.child_hash(true),
             self.child_hash(false),

--- a/src/tree/ops.rs
+++ b/src/tree/ops.rs
@@ -16,7 +16,7 @@ impl fmt::Debug for Op {
             f,
             "{}",
             match self {
-                Put(value) => format!("Put({:?})", value),
+                Put(value) => format!("Put({value:?})"),
                 Delete => "Delete".to_string(),
             }
         )
@@ -450,8 +450,7 @@ mod test {
     #[test]
     fn apply_empty_none() {
         let (maybe_tree, deleted_keys) =
-            Walker::<PanicSource>::apply_to(None, &vec![], PanicSource {})
-                .expect("apply_to failed");
+            Walker::<PanicSource>::apply_to(None, &[], PanicSource {}).expect("apply_to failed");
         assert!(maybe_tree.is_none());
         assert!(deleted_keys.is_empty());
     }


### PR DESCRIPTION
This PR addresses the "TODO" items that appear in the hash.rs file pertaining to generalizing those functions to work with arbitrary "hashers" (structures that implement `Digest`).