### PR TITLE
Remove unwraps from Debug implementation for Tree type

### DIFF
--- a/src/tree/debug.rs
+++ b/src/tree/debug.rs
@@ -15,10 +15,10 @@ impl Debug for Tree {
             if let Some(child_link) = cursor.link(true) {
                 stack.push((child_link.key().to_vec(), cursor.key().to_vec()));
                 if let Some(child_tree) = child_link.tree() {
-                    traverse(f, child_tree, stack, true)?;
+                    traverse(f, child_tree, stack, true)
                 } else {
-                    traverse_pruned(f, child_link, stack, true)?;
-                }
+                    traverse_pruned(f, child_link, stack, true)
+                }?;
                 stack.pop();
             }
 

--- a/src/tree/debug.rs
+++ b/src/tree/debug.rs
@@ -49,10 +49,10 @@ impl Debug for Tree {
             if let Some(child_link) = cursor.link(false) {
                 stack.push((cursor.key().to_vec(), child_link.key().to_vec()));
                 if let Some(child_tree) = child_link.tree() {
-                    traverse(f, child_tree, stack, false)?;
+                    traverse(f, child_tree, stack, false)
                 } else {
-                    traverse_pruned(f, child_link, stack, false)?;
-                }
+                    traverse_pruned(f, child_link, stack, false)
+                }?;
                 stack.pop();
             }
             Ok(())

--- a/src/tree/debug.rs
+++ b/src/tree/debug.rs
@@ -1,22 +1,23 @@
-use super::{Link, Tree};
-use colored::Colorize;
-use std::fmt::{Debug, Formatter, Result};
+use {
+    super::{Link, Tree},
+    colored::Colorize,
+    std::fmt::{Debug, Formatter, Result},
+};
 
 impl Debug for Tree {
-    // TODO: unwraps should be results that bubble up
     fn fmt(&self, f: &mut Formatter) -> Result {
         fn traverse(
             f: &mut Formatter,
             cursor: &Tree,
             stack: &mut Vec<(Vec<u8>, Vec<u8>)>,
             left: bool,
-        ) {
+        ) -> Result {
             if let Some(child_link) = cursor.link(true) {
                 stack.push((child_link.key().to_vec(), cursor.key().to_vec()));
                 if let Some(child_tree) = child_link.tree() {
-                    traverse(f, child_tree, stack, true);
+                    traverse(f, child_tree, stack, true)?;
                 } else {
-                    traverse_pruned(f, child_link, stack, true);
+                    traverse_pruned(f, child_link, stack, true)?;
                 }
                 stack.pop();
             }
@@ -27,7 +28,7 @@ impl Debug for Tree {
                 // draw ancestor's vertical lines
                 for (low, high) in stack.iter().take(depth - 1) {
                     let draw_line = cursor.key() > low && cursor.key() < high;
-                    write!(f, "{}", if draw_line { " │  " } else { "    " }.dimmed()).unwrap();
+                    write!(f, "{}", if draw_line { " │  " } else { "    " }.dimmed())?;
                 }
             }
 
@@ -43,18 +44,18 @@ impl Debug for Tree {
                 "{}{}",
                 prefix.dimmed(),
                 format!("{:?}", cursor.key()).on_bright_black()
-            )
-            .unwrap();
+            )?;
 
             if let Some(child_link) = cursor.link(false) {
                 stack.push((cursor.key().to_vec(), child_link.key().to_vec()));
                 if let Some(child_tree) = child_link.tree() {
-                    traverse(f, child_tree, stack, false);
+                    traverse(f, child_tree, stack, false)?;
                 } else {
-                    traverse_pruned(f, child_link, stack, false);
+                    traverse_pruned(f, child_link, stack, false)?;
                 }
                 stack.pop();
             }
+            Ok(())
         }
 
         fn traverse_pruned(
@@ -62,7 +63,7 @@ impl Debug for Tree {
             link: &Link,
             stack: &mut Vec<(Vec<u8>, Vec<u8>)>,
             left: bool,
-        ) {
+        ) -> Result {
             let depth = stack.len();
 
             if depth > 0 {
@@ -86,11 +87,10 @@ impl Debug for Tree {
                 prefix.dimmed(),
                 format!("{:?}", link.key()).blue()
             )
-            .unwrap();
         }
 
         let mut stack = vec![];
-        traverse(f, self, &mut stack, false);
+        traverse(f, self, &mut stack, false)?;
         writeln!(f)
     }
 }


### PR DESCRIPTION
This PR clears a TODO which surfaces errors explicitly from the writes inside the `Debug` implementation of the `Tree` type, instead of resorting to panicking.